### PR TITLE
统一参考页面中的逗号

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -3,8 +3,8 @@
 - [产品手册中文写作规范](http://wenku.baidu.com/view/23cc1a6527d3240c8447efbf.html), by 华为
 - [写作规范和格式规范](http://docs.daocloud.io/write-docs/format), by DaoCloud
 - [技术写作技巧在日汉翻译中的应用](http://www.hitachi-tc.co.jp/company/thesis/thesis.pdf), by 刘方
-- [简体中文规范指南](https://www.lengoo.de/documents/styleguides/lengoo_styleguide_ZH.pdf)，by lengoo
+- [简体中文规范指南](https://www.lengoo.de/documents/styleguides/lengoo_styleguide_ZH.pdf), by lengoo
 - [文档风格指南](https://open.leancloud.cn/copywriting-style-guide.html), by LeanCloud
 - [豌豆荚文案风格指南](https://docs.google.com/document/d/1R8lMCPf6zCD5KEA8ekZ5knK77iw9J-vJ6vEopPemqZM/edit), by 豌豆荚
-- [中文文案排版指北](https://github.com/sparanoid/chinese-copywriting-guidelines)，by sparanoid
-- [中文排版需求](http://w3c.github.io/clreq/)，by W3C
+- [中文文案排版指北](https://github.com/sparanoid/chinese-copywriting-guidelines), by sparanoid
+- [中文排版需求](http://w3c.github.io/clreq/), by W3C


### PR DESCRIPTION
- 参考列表页中的逗号没有统一，有的是全角有的是半角，由于全都是中英文混合的句子，而逗号后面接的文字是英文，建议采用半角都好。